### PR TITLE
Force logic module to be loaded for dist version

### DIFF
--- a/example/no-comply/index.html
+++ b/example/no-comply/index.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <script src="../../src/gladius.js"></script>
+        <!-- <script src="../../src/gladius.js"></script> -->
+        <script src="../../dist/gladius.js"></script>  
         <script src="nocomply.js"></script>
         
         <style>

--- a/src/gladius-src.js
+++ b/src/gladius-src.js
@@ -11,13 +11,13 @@ define( function ( require ) {
         Event = require( 'core/event' ),
         Queue = require( 'common/queue' ),
 
-    // Services
+        // Services
         Service = require( 'base/service' ),
         Graphics = require( './graphics/service' ),
         Physics = require( './physics/2d/box2d/service' ),
         Input = require( './input/service' ),
         // ActionLists = require( './behavior/action-list/service' ),
-
+        Logic = require('./logic/game/service'),
         Resource = require( 'base/resource' ),
         Space = require( 'core/space' ),
         Component = require( 'base/component' ),


### PR DESCRIPTION
The game logic service needs to be force-loaded for the minified version, as the no-comply demo depends on it.
