### PR TITLE
Wip core

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -23,7 +23,6 @@
     "expect",
     "notEqual",
     "ok",
-    "okay",
     "deepEqual",
     
     // HTML5 browser APIs that jshint will learn about someday

--- a/.jshintrc
+++ b/.jshintrc
@@ -23,6 +23,7 @@
     "expect",
     "notEqual",
     "ok",
+    "okay",
     "deepEqual",
     
     // HTML5 browser APIs that jshint will learn about someday

--- a/examples/camera-rotate/camera-rotate.js
+++ b/examples/camera-rotate/camera-rotate.js
@@ -89,9 +89,10 @@ document.addEventListener( "DOMContentLoaded", function( e ) {
       ]
     ));
 
-    for (var xCoord = -11; xCoord < 11; xCoord = xCoord + 2){
-      for (var yCoord = -11; yCoord < 11; yCoord = yCoord + 2){
-        for (var zCoord = -11; zCoord < 11; zCoord = zCoord + 2){
+    var xCoord, yCoord, zCoord;
+    for (xCoord = -11; xCoord < 11; xCoord = xCoord + 2){
+      for (yCoord = -11; yCoord < 11; yCoord = yCoord + 2){
+        for (zCoord = -11; zCoord < 11; zCoord = zCoord + 2){
           space.add(new engine.simulation.Entity("cubex:" + xCoord + "y:" + yCoord + "z:" + zCoord,
             [
               new engine.core.Transform( [xCoord, yCoord, zCoord], [0, 0, 0], [ 0.1, 0.1, 0.1 ] ),

--- a/src/core/space.js
+++ b/src/core/space.js
@@ -17,19 +17,6 @@ define( function( require ) {
     return this;
   }
 
-  var Space = function( clock ) {
-    // This will normally be the system simulation clock, but for a UI space
-    // it might be the realtime clock instead.
-    this.clock = new Clock( clock.signal ); // This clock controls updates for
-                                            // all entities in this space
-    this.id = guid();
-    this.size = 0; // The number of entities in this space
-
-    this._entities = {}; // Maps entity ID to object
-    this._nameIndex = {}; // Maps name to entity ID
-    this._tagIndex = {}; // Maps tag to entity ID
-  };
-
   function add( entity ) {
     var i, l;
 
@@ -168,6 +155,20 @@ define( function( require ) {
     
     return result;
   }
+
+  function Space( clock ) {
+    // This will normally be the system simulation clock, but for a UI space
+    // it might be the realtime clock instead.
+    console.log("in space");
+    this.clock = new Clock( clock.signal ); // This clock controls updates for
+                                            // all entities in this space
+    this.id = guid();
+    this.size = 0; // The number of entities in this space
+
+    this._entities = {}; // Maps entity ID to object
+    this._nameIndex = {}; // Maps name to entity ID
+    this._tagIndex = {}; // Maps tag to entity ID
+  };
 
   Space.prototype = {
       add: add,

--- a/src/core/space.js
+++ b/src/core/space.js
@@ -168,7 +168,7 @@ define( function( require ) {
     this._entities = {}; // Maps entity ID to object
     this._nameIndex = {}; // Maps name to entity ID
     this._tagIndex = {}; // Maps tag to entity ID
-  };
+  }
 
   Space.prototype = {
       add: add,

--- a/src/core/space.js
+++ b/src/core/space.js
@@ -8,15 +8,6 @@ define( function( require ) {
   var Entity = require( "core/entity" );
   var Clock = require( "core/clock" );
 
-  // Removes value from array and returns the array
-  function removeFromArray( array, value ) {
-    var index = array.indexOf( value );
-    if( index > 0 ) {
-      array.splice( index, 1 );
-    }
-    return this;
-  }
-
   function add( entity ) {
     var i, l;
 
@@ -66,7 +57,7 @@ define( function( require ) {
       if( entity.tags ) {
         for( i = 0, l = entity.tags.length; i < l; ++ i ) {
           var tag = entity.tags[i];
-          removeFromArray( this._tagIndex, entity.id );
+          delete this._tagIndex[entity.id];
         }
       }
 
@@ -159,7 +150,6 @@ define( function( require ) {
   function Space( clock ) {
     // This will normally be the system simulation clock, but for a UI space
     // it might be the realtime clock instead.
-    console.log("in space");
     this.clock = new Clock( clock.signal ); // This clock controls updates for
                                             // all entities in this space
     this.id = guid();

--- a/src/core/space.test.js
+++ b/src/core/space.test.js
@@ -1,11 +1,26 @@
 define(
-    [ "core/space" ],
-    function( Space ) {
+    [ "core/space", "core/clock" ],
+    function( Space, Clock ) {
       return function() {
 
         module( "Space", {
           setup: function() {},
           teardown: function() {}
+        });
+        
+        test("Constructing a space", function(){
+          expect(-1);
+
+          // test construction without a clock;          
+          var mySpace = new Space();
+          
+          okay(mySpace.id, "space has an id");
+          equal(mySpace.size, 0, "space has no entities");
+          deepEqual(mySpace._entities, {}, "entity object is empty");
+          deepEqual(mySpace._nameIndex, {}, "nameIndex object is empty");
+          deepEqual(mySpace._tagIndex, {}, "tagIndex object is empty");
+          okay(mySpace.clock instanceof Clock);
+          // TD test signal is same as simulation with no args to constructor
         });
                
       };

--- a/src/core/space.test.js
+++ b/src/core/space.test.js
@@ -7,6 +7,7 @@ define(
           setup: function() {},
           teardown: function() {}
         });
+ 
         
         test("Constructing a space with new clock", function(){
           expect(6);
@@ -21,6 +22,7 @@ define(
           ok(mySpace.clock instanceof Clock);
         });
 
+
         test("Constructing a space without a clock", function(){
           expect(6);
 
@@ -33,21 +35,24 @@ define(
           ok(mySpace.clock instanceof Clock);
         });
 
-        test("Add entities works normally", function(){
-          expect(8);
+
+        // XXX split up into add/remove test & tagged test
+        test("basic adding, removing, and finding entities works", function(){
+          expect(6);
           var clock = new Clock();
           var mySpace = new Space(clock);
 
-          var entityDupe1 = new Entity("duplicate", [], ["uniqueTag1", "commonTag"]);
-          var entityDupe2 = new Entity("duplicate", [], ["uniqueTag2", "commonTag"]);
-          var uniqueNameEntity = new Entity("unique", [], ["commonTag"]);
+          var entityDupe1 = new Entity("duplicate", [], ["uniqueTag1"]);
+          var entityDupe2 = new Entity("duplicate", [], []);
+          var uniqueNameEntity = new Entity("unique", [], []);
           var emptyEntity = new Entity();
 
           mySpace.add(emptyEntity);
           equal(mySpace.size, 1, "empty entity added properly");
 
           mySpace.add(uniqueNameEntity);
-          equal(mySpace.findNamed("unique"), uniqueNameEntity, "single entity added properly");
+          equal(mySpace.findNamed("unique"), uniqueNameEntity,
+            "single entity added properly");
 
           mySpace.add(entityDupe1);
           mySpace.add(entityDupe2);
@@ -56,12 +61,23 @@ define(
           equal(mySpace.findNamed("duplicate").tags[0], "uniqueTag1",
             "make sure that findNamed returns the first of duplicate names");
 
-          deepEqual(mySpace.findAllTagged("commonTag"), [uniqueNameEntity, entityDupe1, entityDupe2],
-            "find all tagged returns the correct items");
+          mySpace.remove(uniqueNameEntity);            
+          mySpace.remove(emptyEntity);
+          mySpace.remove(entityDupe1);
+          mySpace.remove(entityDupe2);
+          equal(mySpace.size, 0,
+            "removing all added entities results in empty space");
 
-          equal(mySpace.findTagged("uniqueTag1"), entityDupe1,
-            "find tagged returns the first of multiple entities with the same tag");
+          mySpace.remove(uniqueNameEntity); // already removed
+          ok(true, "removing an entity that is not in a space does not throw");
+        });
 
+        
+        test("add and remove handle entities with children", function() {
+          expect(2);
+          var clock = new Clock();
+          var mySpace = new Space(clock);          
+          
           var parentEntity = new Entity("parent", [], []);
           var childEntity = new Entity("child", [], [], parentEntity);
 
@@ -72,9 +88,72 @@ define(
           mySpace.remove(parentEntity);
           equal(mySpace.findNamed("child"), null,
             "space recursively removes child entities");
+        });
 
 
-          //Find entities with a given component type
+        test("finding tagged entities", function() {
+          expect(6);
+          var clock = new Clock();
+          var mySpace = new Space(clock);          
+
+          var entity1 = new Entity("entity1", [], ["tag1"]);
+          var entity2 = new Entity("entity2", [], ["tag2", "tag1"]);
+          
+          equal(mySpace.findTagged("tag1"), null, 
+            "findTagged should return null if no entities present");
+
+          deepEqual(mySpace.findAllWith("tag1"), [], 
+            "findAllTagged should return empty array if no entities present");
+            
+          mySpace.add(entity1);
+          mySpace.add(entity2);
+
+          // note that these tests enforce return in the order entities added
+          deepEqual(mySpace.findTagged("tag1"), entity1, 
+            "findTagged should return the first entity added of a given type");
+          deepEqual(mySpace.findAllTagged("tag1"), [entity1, entity2], 
+            "findAllTagged should return all entities of a given type in order");
+
+          equal(mySpace.findTagged("NoSuchTag"), null, 
+            "findTagged should return null if no entities of given type present");
+          deepEqual(mySpace.findAllTagged("NoSuchTag"), [], 
+            "findAllTagged should return [] if no entities of given type present");
+        });
+                
+        
+        test("finding entities with a type of component", function() {
+          expect(6);
+          var clock = new Clock();
+          var mySpace = new Space(clock);          
+
+          var component1 = {
+              type: "Type1",
+              dependsOn: [],
+              setOwner: function() {}
+          };
+
+          var entity1 = new Entity("entity1", [component1], []);
+          var entity2 = new Entity("entity2", [component1], []);
+
+          equal(mySpace.findWith("Type1"), null, 
+            "findWith should return null if no entities present");
+
+          deepEqual(mySpace.findAllWith("Type1"), [], 
+            "findAllWith should return empty array if no entities present");
+            
+          mySpace.add(entity1);
+          mySpace.add(entity2);
+
+          // note that these tests enforce return in the order entities added
+          deepEqual(mySpace.findWith("Type1"), entity1, 
+            "findWith should return the first entity added of a given type");
+          deepEqual(mySpace.findAllWith("Type1"), [entity1, entity2], 
+            "findAllWith should return all entities of a given type in order");
+
+          equal(mySpace.findWith("NoSuchType"), null, 
+            "findWith should return null if no entities of given type present");
+          deepEqual(mySpace.findAllWith("NoSuchType"), [], 
+            "findAllWith should return [] if no entities of given type present");
         });
                
       };

--- a/src/core/space.test.js
+++ b/src/core/space.test.js
@@ -1,6 +1,6 @@
 define(
-    [ "core/space", "core/clock" ],
-    function( Space, Clock ) {
+    [ "core/space", "core/clock", "core/entity" ],
+    function( Space, Clock, Entity ) {
       return function() {
 
         module( "Space", {
@@ -8,19 +8,73 @@ define(
           teardown: function() {}
         });
         
-        test("Constructing a space", function(){
-          expect(-1);
-
-          // test construction without a clock;          
-          var mySpace = new Space();
+        test("Constructing a space with new clock", function(){
+          expect(6);
+          var clock = new Clock();
+          var mySpace = new Space(clock);
           
-          okay(mySpace.id, "space has an id");
+          ok(mySpace.id, "space has an id");
           equal(mySpace.size, 0, "space has no entities");
           deepEqual(mySpace._entities, {}, "entity object is empty");
           deepEqual(mySpace._nameIndex, {}, "nameIndex object is empty");
           deepEqual(mySpace._tagIndex, {}, "tagIndex object is empty");
-          okay(mySpace.clock instanceof Clock);
-          // TD test signal is same as simulation with no args to constructor
+          ok(mySpace.clock instanceof Clock);
+        });
+
+        test("Constructing a space without a clock", function(){
+          expect(6);
+
+          // test construction without a clock;
+          var mySpace = new Space();
+
+          //TODO: Figure out why calling new Space without a parameter works at
+          // all in any case, and determine what should be done in the case when
+          //one isn't passed in, because it just breaks right now
+          ok(mySpace.clock instanceof Clock);
+        });
+
+        test("Add entities works normally", function(){
+          expect(8);
+          var clock = new Clock();
+          var mySpace = new Space(clock);
+
+          var entityDupe1 = new Entity("duplicate", [], ["uniqueTag1", "commonTag"]);
+          var entityDupe2 = new Entity("duplicate", [], ["uniqueTag2", "commonTag"]);
+          var uniqueNameEntity = new Entity("unique", [], ["commonTag"]);
+          var emptyEntity = new Entity();
+
+          mySpace.add(emptyEntity);
+          equal(mySpace.size, 1, "empty entity added properly");
+
+          mySpace.add(uniqueNameEntity);
+          equal(mySpace.findNamed("unique"), uniqueNameEntity, "single entity added properly");
+
+          mySpace.add(entityDupe1);
+          mySpace.add(entityDupe2);
+          equal(mySpace.findAllNamed("duplicate").length, 2,
+            "make sure that multiple colliding names are shoved into an array");
+          equal(mySpace.findNamed("duplicate").tags[0], "uniqueTag1",
+            "make sure that findNamed returns the first of duplicate names");
+
+          deepEqual(mySpace.findAllTagged("commonTag"), [uniqueNameEntity, entityDupe1, entityDupe2],
+            "find all tagged returns the correct items");
+
+          equal(mySpace.findTagged("uniqueTag1"), entityDupe1,
+            "find tagged returns the first of multiple entities with the same tag");
+
+          var parentEntity = new Entity("parent", [], []);
+          var childEntity = new Entity("child", [], [], parentEntity);
+
+          mySpace.add(parentEntity);
+          equal(mySpace.findNamed("child"), childEntity,
+            "space recursively adds child entities");
+
+          mySpace.remove(parentEntity);
+          equal(mySpace.findNamed("child"), null,
+            "space recursively removes child entities");
+
+
+          //Find entities with a given component type
         });
                
       };


### PR DESCRIPTION
Here are a bunch of spaces test dperit and I worked out, some paired, some not.  One of them currently fails in an odd way, more on that in a bit.

I moved the spaces constructor next to the prototype in the spaces.js file, as that's standard style and where folks would generally expect to look.

Questions that came up while writing these tests:

The engine has its own RealTimeClock.  Is this likely to be as accurate as date.now() or the new high-perf timers?  Does that matter?

For the tests, we ended up reaching inside Entity somewhat.  It wasn't clear to us why entity._children was a private member.  Is there some reason components people shouldn't be able to inspect it?

It's currently possible to create a completely empty entity by supplying no arguments to the constructor.  Is there a use case for this, or should it throw?

find(All)With is a little terse as far as names go.  Maybe findWithComponentType?

Would it make sense for add() and remove() to return the values they were passed to make for easy chaining?

Right now, removing an entity that's not in a space doesn't do anything or notify the caller.  Should it (for example) throw?

These tests nail down a deterministic return order for the various find and findAll (items should be returned in the order added), in part because those were the easier tests to write, but also under the theory that a deterministic API is likely to be less surprising to people who read docs closely (most people).

Finally, doing new Space() without arguments works in the examples which include the engine, because by some black magic, the space constructor ends up with a clock local variable that's non-empty.  dperit and i don't see how this is possible.   The unit test for that, however, fails, because the code behaves the way we would expect from reading it.  Insight here would be much appreciated.

From reading the comments in the Space constructor(), that unit test should actually be testing not just the the clock is an instanceof Clock, but probably that it's an instance of the system clock.  Would you agree?
If so, it's not entirely clear how one would test that without depending on the engine.  Thoughts?
